### PR TITLE
ginn5lc - 2: Return overall tally info to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@ List of ideas to implement prior to alpha release.
 - Standardize all the ids, classes, etc so there is no concern about namespace collisions (i.e., prefix everything with tf7_)
 
 ### PHP
-- Return overall tally info to client
-    - Create get tally function. Return array of arrays of the overall tally. First level keyed by player id; second level keyed by statistic (sum of 7, 24, run of 3, etc)
-    - Get and return overall tally in get all datas function
-    - Get and return overall tally in the new scores notification
 - Standardize all the ids, classes, etc so there is no concern about namespace collisions (i.e., prefix everything with tf7_)
 - Implement zombie turn
 

--- a/twentyfourseven.game.php
+++ b/twentyfourseven.game.php
@@ -272,7 +272,7 @@ class TwentyFourSeven extends Table
         // Get player ids
         $player_ids =  array_keys($this->loadPlayersBasicInfos());
 
-        foreach( $player_ids as $player_id)
+        foreach( $player_ids as $player_id )
         {
             foreach ( self::STAT_KEYS as $stat )
             {

--- a/twentyfourseven.game.php
+++ b/twentyfourseven.game.php
@@ -66,6 +66,19 @@ class TwentyFourSeven extends Table
         self::BONUS     => [ "description" => "Bonus",     "minutes" => 60 ]
     ];
 
+    private const STAT_KEYS = [
+        'turns_number',
+        'tally_sum_of_7',
+        'tally_sum_of_24',
+        'tally_run_of_3',
+        'tally_run_of_4',
+        'tally_run_of_5',
+        'tally_run_of_6',
+        'tally_set_of_3',
+        'tally_set_of_4',
+        'tally_bonus'
+    ];
+
 	function __construct( )
 	{
         // Your global variables labels:
@@ -254,16 +267,14 @@ class TwentyFourSeven extends Table
     protected function getPlayersTally()
     {
         $result = array();
-        $stats = array('turns_number', 'tally_sum_of_7', 'tally_sum_of_24', 'tally_run_of_3', 'tally_run_of_4', 'tally_run_of_5', 'tally_run_of_6', 'tally_set_of_3', 'tally_set_of_4', 'tally_bonus');
         $player_stats = array();
+        
         // Get player ids
-        // Note: you can retrieve some extra field you added for "player" table in "dbmodel.sql" if you need it.
-        $sql = "SELECT player_id id FROM player ";
-        $players = self::getCollectionFromDb( $sql );
+        $player_ids =  array_keys($this->loadPlayersBasicInfos());
 
-        foreach( $players as $player_id => $player )
+        foreach( $player_ids as $player_id)
         {
-            foreach ( $stats as $stat )
+            foreach ( self::STAT_KEYS as $stat )
             {
                 $player_stats[$stat] = self::getStat( $stat, $player_id );
             }

--- a/twentyfourseven.game.php
+++ b/twentyfourseven.game.php
@@ -235,6 +235,43 @@ class TwentyFourSeven extends Table
         // Playable spaces on the board
         $result['spaces'] = self::getPlayableSpaces();
 
+        // Tallies for both players stats
+        $result['tallies'] = self::getPlayersTally();
+
+        return $result;
+    }
+
+    /*
+        getPlayersTally:
+
+        Gather all the players stats.
+        Place the stats data into an array of arrays keyed first by player id and then stat.
+
+        The method is called:
+        - in the getAllDatas function
+        - in the newScores notif
+    */
+    protected function getPlayersTally()
+    {
+        $result = array();
+        $stats = array('turns_number', 'tally_sum_of_7', 'tally_sum_of_24', 'tally_run_of_3', 'tally_run_of_4', 'tally_run_of_5', 'tally_run_of_6', 'tally_set_of_3', 'tally_set_of_4', 'tally_bonus');
+        $player_stats = array();
+        // Get player ids
+        // Note: you can retrieve some extra field you added for "player" table in "dbmodel.sql" if you need it.
+        $sql = "SELECT player_id id FROM player ";
+        $players = self::getCollectionFromDb( $sql );
+
+        foreach( $players as $player_id => $player )
+        {
+            foreach ( $stats as $stat )
+            {
+                $player_stats[$stat] = self::getStat( $stat, $player_id );
+            }
+            $result[$player_id] = $player_stats;
+        }
+        unset( $player_id );
+        unset( $stat );
+
         return $result;
     }
 
@@ -965,8 +1002,10 @@ class TwentyFourSeven extends Table
              * New scores notification
              */
             $newScores = self::getCollectionFromDb( "SELECT player_id, player_score FROM player", true );
+            $tallies = self::getPlayersTally();
             self::notifyAllPlayers( "newScores", "", array(
-                "scores" => $newScores
+                "scores" => $newScores,
+                "tallies" => $tallies
             ) );
 
             /*

--- a/twentyfourseven.js
+++ b/twentyfourseven.js
@@ -368,6 +368,9 @@ function (dojo, declare) {
             for( const player_id in notif.args.scores )
             {
                 var newScore = notif.args.scores[ player_id ];
+                var newTally = notif.args.tallies[ player_id ];
+                console.log(player_id);
+                console.log(newTally);
                 this.scoreCtrl[ player_id ].toValue( newScore );
             }
         },


### PR DESCRIPTION
* Create get tally function. Return array of arrays of the overall tally. First level keyed by player id; second level keyed by statistic (sum of 7, 24, run of 3, etc)
    * Get and return overall tally in get all datas function
    * Get and return overall tally in the new scores notification
    
* Called and returned on game setup
<img width="1792" alt="Screen Shot 2022-06-27 at 2 40 43 PM" src="https://user-images.githubusercontent.com/32302951/176034401-524c0eab-6df8-4da3-9df6-ffc403510856.png">

* Called and returned on page refresh ( tallies are up to date )
<img width="1792" alt="Screen Shot 2022-06-27 at 2 40 56 PM" src="https://user-images.githubusercontent.com/32302951/176035345-07e6083a-98d1-44d1-ab0e-52f305767dbb.png">

* Called and returned during newScores notif
<img width="1792" alt="Screen Shot 2022-06-27 at 2 51 34 PM" src="https://user-images.githubusercontent.com/32302951/176035524-c895fd55-e6a8-4948-8ee3-be9d9504dcc5.png">


